### PR TITLE
fix(PLT-3359): harden yarn configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: '/'
+    registries:
+      - gh-packages
     schedule:
       interval: weekly
     versioning-strategy: increase

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-
 updates:
   - package-ecosystem: npm
     directory: '/'
@@ -17,7 +16,14 @@ updates:
       typeform:
         patterns:
           - '@typeform*'
-
+    cooldown:
+      default-days: 7
+      exclude:
+        - '@typeform/*'
+    ignore:
+      - dependency-name: semantic-release
+        versions:
+          - '>=25.0.0'
 registries:
   gh-packages:
     type: npm-registry

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,2 @@
+ignore-scripts true
+save-exact true


### PR DESCRIPTION
## Harden yarn configuration
This PR hardens yarn configuration against supply chain attacks.

### Changes
- **`.yarnrc`**: Added `ignore-scripts true` and `save-exact true`.
- **Dependabot**: Added a 7-day `cooldown` for third-party npm updates (excluding `@typeform/*`).
- **Compatibility**: Maintained `semantic-release` version locks for Node 22 compatibility.

---
_Automated by Application Security · supply-chain-hardening_

[_Created by Sourcegraph batch change `david.salvador/harden-yarn-config`._](https://typeform.sourcegraphcloud.com/users/david.salvador/batch-changes/harden-yarn-config)