### PR TITLE
chore(notask): standardize workflow names for monitoring consistency

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Pull Request
+name: Pull Request (Consolidated)
 on:
   pull_request:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Deploy (Consolidated)
 
 on:
   push:


### PR DESCRIPTION
## What

Standardize GitHub Actions workflow `name:` fields to follow the agreed convention:
- PR workflow: `Pull Request (Consolidated)`
- Deploy workflow: `Deploy (Consolidated)`

## Why

Consistent workflow names are needed for:
- Datadog CI Visibility monitoring
- GitHub Actions usage dashboards
- Cross-repo pipeline duration comparisons

## Changes

One-line `name:` field changes in workflow YAML files. No functional changes.

## Related

Part of PLT-2547 CI Consolidation cleanup.